### PR TITLE
Update n8n.yaml to use Docker Hub Official Image instead of N8N regis…

### DIFF
--- a/templates/compose/n8n.yaml
+++ b/templates/compose/n8n.yaml
@@ -6,7 +6,7 @@
 
 services:
   n8n:
-    image: docker.n8n.io/n8nio/n8n
+    image: n8nio/n8n
     environment:
       - SERVICE_FQDN_N8N_5678
       - N8N_EDITOR_BASE_URL=${SERVICE_FQDN_N8N}


### PR DESCRIPTION
…try.

The N8N registry has very low rate limit and if you have an authenticated account in docker hub on the coolify server it should work, but it doesn't. With this one it works perfectly.

## Submit Checklist (REMOVE THIS SECTION BEFORE SUBMITTING)
- [x] I have selected the `next` branch as the destination for my PR, not `main`.
- [x] I have listed all changes in the `Changes` section.
- [x] I have filled out the `Issues` section with the issue/discussion link(s) (if applicable).
- [x] I have tested my changes.
- [x] I have considered backwards compatibility.
- [x] I have removed this checklist and any unused sections.

## Changes
- 

## Issues
- fix #
